### PR TITLE
Pluralization bugs

### DIFF
--- a/__tests__/i18n-json-transform-webpack-plugin.test.ts
+++ b/__tests__/i18n-json-transform-webpack-plugin.test.ts
@@ -1,0 +1,116 @@
+import { transform } from '../src/i18n-json-transform-webpack-plugin';
+
+const bufferToObject = buffer => JSON.parse(buffer.toString());
+const objectToBuffer = object => new Buffer(JSON.stringify(object));
+
+describe('i18n-json-transform-webpack-plugin', () => {
+  describe('transform', () => {
+    it('transforms a buffer of term objects to a buffer of key/value pairs', () => {
+      const terms = [
+        { term: 'term1', definition: 'definition1' },
+        { term: 'term2', definition: 'definition2' }
+      ];
+      const expectedOutput = { term1: 'definition1', term2: 'definition2' };
+      const inputBuffer = objectToBuffer(terms);
+      const output = bufferToObject(transform(inputBuffer));
+
+      expect(output).toEqual(expectedOutput);
+    });
+
+    it('prefers "other", then "many", then "few" as the plural definition', () => {
+      const terms = [
+        {
+          term: 'term1',
+          definition: {
+            one: 'def1',
+            other: 'other',
+            many: 'many',
+            few: 'few'
+          }
+        },
+        {
+          term: 'term2',
+          definition: {
+            one: 'def2',
+            many: 'many',
+            few: 'few'
+          }
+        },
+        {
+          term: 'term3',
+          definition: {
+            one: 'def3',
+            few: 'few'
+          }
+        }
+      ];
+
+      const expectedOutput = {
+        term1: 'def1',
+        term1_plural: 'other',
+        term2: 'def2',
+        term2_plural: 'many',
+        term3: 'def3',
+        term3_plural: 'few'
+      };
+
+      const inputBuffer = objectToBuffer(terms);
+      const output = bufferToObject(transform(inputBuffer));
+
+      expect(output).toEqual(expectedOutput);
+    });
+  });
+
+  it('transforms both singular and plural definitions', () => {
+    const terms = [
+      {
+        term: 'term1',
+        definition: {
+          one: 'one',
+          other: 'other'
+        }
+      }
+    ];
+
+    const expectedOutput = { term1: 'one', term1_plural: 'other' };
+
+    const inputBuffer = objectToBuffer(terms);
+    const output = bufferToObject(transform(inputBuffer));
+
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it('uses the plural as singular if only plural is specified', () => {
+    const terms = [
+      {
+        term: 'term1',
+        definition: {
+          other: 'plural'
+        }
+      }
+    ];
+
+    const expectedOutput = { term1: 'plural', term1_plural: 'plural' };
+
+    const inputBuffer = objectToBuffer(terms);
+    const output = bufferToObject(transform(inputBuffer));
+
+    expect(output).toEqual(expectedOutput);
+  });
+
+  it('uses the original term if no definition is found', () => {
+    const terms = [
+      {
+        term: 'term1',
+        definition: ''
+      }
+    ];
+
+    const expectedOutput = { term1: 'term1' };
+
+    const inputBuffer = objectToBuffer(terms);
+    const output = bufferToObject(transform(inputBuffer));
+
+    expect(output).toEqual(expectedOutput);
+  });
+});

--- a/__tests__/i18n-json-transform-webpack-plugin.test.ts
+++ b/__tests__/i18n-json-transform-webpack-plugin.test.ts
@@ -130,7 +130,12 @@ describe('i18n-json-transform-webpack-plugin', () => {
       }
     ];
 
-    const expectedOutput = { term1: 'other', term2: 'other2' };
+    const expectedOutput = {
+      term1: 'other',
+      term1_plural: 'other',
+      term2: 'other2',
+      term2_plural: 'other2'
+    };
 
     const inputBuffer = objectToBuffer(terms);
     const output = bufferToObject(transform(inputBuffer));

--- a/__tests__/i18n-json-transform-webpack-plugin.test.ts
+++ b/__tests__/i18n-json-transform-webpack-plugin.test.ts
@@ -113,4 +113,28 @@ describe('i18n-json-transform-webpack-plugin', () => {
 
     expect(output).toEqual(expectedOutput);
   });
+
+  it('writes object definitions dynamically', () => {
+    const terms = [
+      {
+        term: 'term1',
+        definition: {
+          other: 'other'
+        }
+      },
+      {
+        term: 'term2',
+        definition: {
+          other: 'other2'
+        }
+      }
+    ];
+
+    const expectedOutput = { term1: 'other', term2: 'other2' };
+
+    const inputBuffer = objectToBuffer(terms);
+    const output = bufferToObject(transform(inputBuffer));
+
+    expect(output).toEqual(expectedOutput);
+  });
 });

--- a/src/i18n-json-transform-webpack-plugin.ts
+++ b/src/i18n-json-transform-webpack-plugin.ts
@@ -6,6 +6,8 @@ export const transform = (buffer) => {
     const { term } = translation;
     const definition = translation.definition || '';
     const { one, other, many, few } = definition;
+    const plural = other || many || few;
+
     if (typeof definition !== 'object') {
       let def = (typeof definition === 'string') && definition;
       def = def || other || many || few || term;
@@ -15,15 +17,10 @@ export const transform = (buffer) => {
       );
     }
 
-    if (definition && one) {
-      const plural = other || many || few || term;
-      return Object.assign(result,
-        { [term]: one || term },
-        other && { [`${term}_plural`]: plural },
-      );
-    }
-
-    return Object.assign(result, { [term]: term });
+    return Object.assign(result,
+      { [term]: one || plural || term },
+      plural && { [`${term}_plural`]: plural || term },
+    );
   }, {});
 
   return Buffer.from(JSON.stringify(newContent, null, 2));

--- a/src/i18n-json-transform-webpack-plugin.ts
+++ b/src/i18n-json-transform-webpack-plugin.ts
@@ -1,6 +1,6 @@
 import * as CopyPlugin from 'copy-webpack-plugin';
 
-const transform = (buffer) => {
+export const transform = (buffer) => {
   const content = JSON.parse(buffer.toString());
   const newContent = content.reduce((result, translation) => {
     const { term } = translation;

--- a/src/i18n-json-transform-webpack-plugin.ts
+++ b/src/i18n-json-transform-webpack-plugin.ts
@@ -23,7 +23,7 @@ export const transform = (buffer) => {
       );
     }
 
-    return Object.assign(result, { term });
+    return Object.assign(result, { [term]: term });
   }, {});
 
   return Buffer.from(JSON.stringify(newContent, null, 2));


### PR DESCRIPTION
This fixes a few issues related to how the library handles terms with plural definitions. Namely:

* terms were being overwritten if they only had a plural definition
* terms did not get a singular definition if only a plural was defined (JA does not distinguish and was only providing the plural, so this case needed to be handled)