### PR TITLE
Order output terms by term string

### DIFF
--- a/__tests__/i18n-json-webpack-loader.test.ts
+++ b/__tests__/i18n-json-webpack-loader.test.ts
@@ -153,5 +153,16 @@ describe('i18n-json-loader', () => {
       expect(ja).toEqual(expect.arrayContaining(expectedTerms));
       expect(ja.length).toEqual(10);
     });
+
+    it('writes terms in asciibetical order', () => {
+      const terms = [ 'abc', '{{thing}}', 'bcd', '12', 'zzz' ];
+      const output = writeTermsToFiles(terms);
+
+      const en = JSON.parse(output.en);
+      const outputTerms = en.map(translation => translation.term);
+      const sortedOutputTerms = [ ...outputTerms ].sort((a, b) => a.localeCompare(b));
+
+      expect(outputTerms).toEqual(sortedOutputTerms);
+    });
   });
 });

--- a/src/i18n-json-webpack-loader.ts
+++ b/src/i18n-json-webpack-loader.ts
@@ -70,6 +70,8 @@ const stringifyTerms = (terms) => {
 export const writeTermsToFiles = (terms: any[]) => {
   return languages().reduce((result, dir) => {
     const translations = loadTranslationFile(dir) || [];
+    const filePath = join(OPTIONS.translationsDir, dir, 'common.json');
+
     const termsToWrite = terms.reduce((result, term) => {
       const match = findTerm(term, translations);
 
@@ -77,9 +79,10 @@ export const writeTermsToFiles = (terms: any[]) => {
       return result;
     }, []);
 
-    const blep = stringifyTerms([ ...translations, ...termsToWrite ]);
-    const filePath = join(OPTIONS.translationsDir, dir, 'common.json');
-    result[dir] = writeFileSync(filePath, blep, 'utf8');
+    const allTerms = [ ...translations, ...termsToWrite ];
+    const sortedTerms = allTerms.sort((a, b) => a.term.localeCompare(b.term));
+
+    result[dir] = writeFileSync(filePath, stringifyTerms(allTerms), 'utf8');
     return result;
   }, {});
 };


### PR DESCRIPTION
Deterministic ordering of terms is never a bad thing. Previously this
ordering was based on the order in which the loader was fed files, which
was generally deterministic (with the exception of FS/globbing
differences).

However, this ordering will greatly help a human to read these files.