### PR TITLE
Fixes nested interpolation, numbering of generated tags

### DIFF
--- a/__tests__/fixtures/interpolated.tsx
+++ b/__tests__/fixtures/interpolated.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { Trans, translate } from 'react-i18next';
+
+class Interpolated extends React.Component<any, any> {
+  render() {
+    const { t } = this.props;
+    const dog = t('bulldog');
+
+    return (
+      <Trans>
+        <div>
+          I own a {{dog}}.
+        </div>
+      </Trans>
+    );
+  }
+}
+
+export default translate('common')(Interpolated);

--- a/__tests__/i18n-json-webpack-loader.test.ts
+++ b/__tests__/i18n-json-webpack-loader.test.ts
@@ -1,8 +1,7 @@
 jest.mock('fs-extra');
 
 import path from 'path';
-import { inspect } from 'util';
-import { compact, filter, find, flatten, matches } from 'lodash';
+import { find, matches } from 'lodash';
 import { transpile } from 'typescript';
 import { parser, writeTermsToFiles } from '../src/i18n-json-webpack-loader';
 
@@ -57,21 +56,21 @@ describe('i18n-json-loader', () => {
 
       it('finds Trans Component text', () => {
         const oneThing = parseFile('./fixtures/child.tsx');
-        // const twoThings = parseFile('./fixtures/parent.tsx');
+        const twoThings = parseFile('./fixtures/parent.tsx');
         const oneTransFunctions = findTransComponents(oneThing);
-        // const twoTransFunctions = findTransComponents(twoThings);
+        const twoTransFunctions = findTransComponents(twoThings);
         const oneMatches = sanitizeTerms(oneTransFunctions);
-        // const twoMatches = sanitizeTerms(twoTransFunctions);
+        const twoMatches = sanitizeTerms(twoTransFunctions);
 
         expect(oneMatches).toEqual(expect.arrayContaining([
           "Text with a <1>one</1>yep <3>{{dog}}</3> dude<5>three</5>A second text with a<7>five<1></1><2>two</2><3>three<1>one</1></3></7><8>six</8><9><0>zero</0>seven</9>",
         ]));
 
-        // expect(twoMatches).toEqual(expect.arrayContaining([
-        //   "Hello <1>{{name}}</1> it's <3>{{day}}</3>",
-        //   'Hello',
-        //   '<0>{{boys}}</0> and <2>{{girls}}</2>'
-        // ]));
+        expect(twoMatches).toEqual(expect.arrayContaining([
+          "Hello <1>{{name}}</1> it's <3>{{day}}</3>",
+          'Hello',
+          '<0>{{boys}}</0> and <2>{{girls}}</2>'
+        ]));
       });
 
       it('replaces html tags in Trans contents with sequential numbers', () => {

--- a/__tests__/i18n-json-webpack-loader.test.ts
+++ b/__tests__/i18n-json-webpack-loader.test.ts
@@ -1,7 +1,7 @@
 jest.mock('fs-extra');
 
 import path from 'path';
-import { find, matches } from 'lodash';
+import { find } from 'lodash';
 import { transpile } from 'typescript';
 import { parser, writeTermsToFiles } from '../src/i18n-json-webpack-loader';
 
@@ -20,17 +20,6 @@ const parseFile = (relativePath) => {
   return tree;
 };
 
-const isTrans = matches({ property: { name: 'Trans' }})
-
-const transMatches = (collection): any[] => {
-  return collection.reduce((matches, item) => {
-    const transMatch = find(item, isTrans)
-    transMatch && matches.push(transMatch);
-
-    return matches;
-  }, []);
-};
-
 describe('i18n-json-loader', () => {
   describe('<Trans />', () => {
     describe('Source Parsing', () => {
@@ -39,11 +28,9 @@ describe('i18n-json-loader', () => {
         const parsedParent = parseFile('./fixtures/parent.tsx');
         const childComponents = findTransComponents(parsedChild);
         const parentComponents = findTransComponents(parsedParent);
-        const childMatches = transMatches(childComponents);
-        const parentMatches = transMatches(parentComponents);
 
-        expect(childMatches.length).toEqual(1);
-        expect(parentMatches.length).toEqual(3);
+        expect(childComponents.length).toEqual(1);
+        expect(parentComponents.length).toEqual(3);
       });
 
       it('interpolation works within HTML tags', () => {

--- a/__tests__/trans.test.ts
+++ b/__tests__/trans.test.ts
@@ -1,0 +1,170 @@
+import { transpile } from 'typescript';
+import { parser, writeTermsToFiles } from '../src/i18n-json-webpack-loader';
+
+import { findTransComponents, sanitizeTerms, isElement, isTrans, replaceTags } from '../src/trans';
+
+const { compilerOptions } = require('../tsconfig.json');
+
+const parse = (string) => parser(transpile(string, compilerOptions));
+
+describe('trans utils', () => {
+  describe('sanitizeTerms', () => {
+    it('does nothing for a simple tag', () => {
+      const program = parse('<Trans>hey there</Trans>');
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['hey there']);
+    });
+
+    it('numbers nested elements', () => {
+      const program = parse('<Trans>hey <strong>there</strong></Trans>');
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['hey <1>there</1>']);
+    });
+
+    it('orders sibling elements based on index', () => {
+      const program = parse('<Trans>hi mom<div>one</div><span>two</span><div>three</div></Trans>');
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['hi mom<1>one</1><2>two</2><3>three</3>']);
+    });
+
+    it('numbers sibling elements sequentially', () => {
+      const program = parse('<Trans><div>one</div><span>two</span><div>three</div></Trans>');
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['<0>one</0><1>two</1><2>three</2>']);
+    });
+
+    it('resets numbering on nested elements', () => {
+      const program = parse(`
+        <Trans>
+          <div>
+            zero
+            <span>
+              zero
+              <span>
+                zero
+              </span>
+            </span>
+          </div>
+          <span>one</span>
+          <div>two</div>
+        </Trans>
+      `);
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['<0>zero<0>zero<0>zero</0></0></0><1>one</1><2>two</2>']);
+    });
+
+    it('wraps an interpolation in a tag', () => {
+      const program = parse('<Trans>hey there {{username}}</Trans>');
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['hey there <1>{{username}}</1>']);
+    });
+
+    it('wraps multiple interpolations in tags', () => {
+      const program = parse('<Trans>hey there {{firstName}} {{lastName}}</Trans>');
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['hey there <1>{{firstName}}</1> <3>{{lastName}}</3>']);
+    });
+
+    it('wraps nested interpolations in tags', () => {
+      const program = parse('<Trans>hey there {{firstName}} <span>{{lastName}}</span></Trans>');
+      const found = findTransComponents(program);
+      const terms = sanitizeTerms(found);
+
+      expect(terms).toEqual(['hey there <1>{{firstName}}</1> <3><0>{{lastName}}</0></3>']);
+    });
+  });
+
+  describe('findTransComponents', () => {
+    it('finds a single element', () => {
+      const program = parse('<Trans>hi there</Trans>');
+      const found = findTransComponents(program);
+
+      expect(found.length).toEqual(1);
+    });
+
+    it('finds sibling elements', () => {
+      const program = parse('<Trans>hi there</Trans><Trans>yo</Trans>');
+      const found = findTransComponents(program);
+
+      expect(found.length).toEqual(2);
+    });
+
+    it('finds nested elements', () => {
+      const program = parse(`
+        <Trans>hi there</Trans>
+        <div>
+          <Trans>yo</Trans>
+          <Trans>bla</Trans>
+        </div>
+      `);
+      const found = findTransComponents(program);
+
+      expect(found.length).toEqual(3);
+    });
+  });
+
+  describe('isElement', () => {
+    it('is true for a self-closing element', () => {
+      const program = parse('<div />');
+      const elementEntity = program.body[0].expression;
+
+      expect(isElement(elementEntity)).toBeTruthy();
+    });
+
+    it('is true for a simple element', () => {
+      const program = parse('<div>hi mom</div>');
+      const elementEntity = program.body[0].expression;
+
+      expect(isElement(elementEntity)).toBeTruthy();
+    });
+
+    it('is false for a full program', () => {
+      const program = parse('<div>hi mom</div>');
+
+      expect(isElement(program)).toBeFalsy();
+    });
+  });
+
+  describe('isTrans', () => {
+    it('is false for a full program', () => {
+      const program = parse('<Trans>hi mom</Trans>');
+
+      expect(isTrans(program)).toBeFalsy();
+    });
+
+    it('is false for a regular element', () => {
+      const program = parse('<div>hi mom</div>');
+      const elementEntity = program.body[0].expression;
+
+      expect(isTrans(elementEntity)).toBeFalsy();
+    });
+
+    it('is true for a Trans element', () => {
+      const program = parse('<Trans>hi mom</Trans>');
+      const elementEntity = program.body[0].expression;
+
+      expect(isTrans(elementEntity)).toBeTruthy();
+    });
+
+    it('is true for a self-closing Trans element', () => {
+      const program = parse('<Trans />');
+      const elementEntity = program.body[0].expression;
+
+      expect(isTrans(elementEntity)).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/trans.test.ts
+++ b/__tests__/trans.test.ts
@@ -45,12 +45,11 @@ describe('trans utils', () => {
       const program = parse(`
         <Trans>
           <div>
-            zero
             <span>
-              zero
-              <span>
-                zero
-              </span>
+              innerZero
+            </span>
+            <span>
+              innerOne
             </span>
           </div>
           <span>one</span>
@@ -60,7 +59,7 @@ describe('trans utils', () => {
       const found = findTransComponents(program);
       const terms = sanitizeTerms(found);
 
-      expect(terms).toEqual(['<0>zero<0>zero<0>zero</0></0></0><1>one</1><2>two</2>']);
+      expect(terms[0]).toEqual('<0><0>innerZero</0><1>innerOne</1></0><1>one</1><2>two</2>');
     });
 
     it('wraps an interpolation in a tag', () => {

--- a/src/trans.ts
+++ b/src/trans.ts
@@ -1,22 +1,27 @@
 import { get, reduce } from 'lodash';
 
 export const isElement = entity =>
-  get(entity, 'type') === 'CallExpression' &&
-  get(entity, 'callee.property.name') === 'createElement';
+  get(entity, 'type') === 'CallExpression'
+  && get(entity, 'callee.property.name') === 'createElement';
 
 export const isTrans = entity =>
-  isElement(entity) &&
-  (get(entity, 'arguments[0].name') === 'Trans' ||
-    get(entity, 'arguments[0].property.name') === 'Trans');
+  isElement(entity)
+  && (
+    get(entity, 'arguments[0].name') === 'Trans'
+    || get(entity, 'arguments[0].property.name') === 'Trans'
+  );
 
 const isInterpolation = entity =>
-  get(entity, 'type') === 'ObjectExpression' &&
-  get(entity, 'properties').length === 1 &&
-  get(entity, 'properties[0].value.type') === 'Identifier';
+  get(entity, 'type') === 'ObjectExpression'
+  && get(entity, 'properties').length === 1
+  && get(entity, 'properties[0].value.type') === 'Identifier';
 
-const interpolationName = entity => get(entity, 'properties[0].value.name');
+const interpolationName = entity =>
+  get(entity, 'properties[0].value.name');
 
-const isLiteral = entity => get(entity, 'type') === 'Literal';
+const isLiteral = entity =>
+  get(entity, 'type') === 'Literal';
+
 const hasValue = entity =>
   typeof entity.value !== 'undefined' && entity.value !== null;
 

--- a/src/trans.ts
+++ b/src/trans.ts
@@ -1,6 +1,4 @@
-import { get, reduce, reject } from 'lodash';
-import { OPTIONS } from './i18n-json-webpack-loader';
-import { generate } from 'escodegen';
+import { get, reduce } from 'lodash';
 
 export const isElement = entity =>
   get(entity, 'type') === 'CallExpression' &&

--- a/src/trans.ts
+++ b/src/trans.ts
@@ -22,29 +22,9 @@ const isLiteral = entity => get(entity, 'type') === 'Literal';
 const hasValue = entity =>
   typeof entity.value !== 'undefined' && entity.value !== null;
 
-// const isCreateElement = isElement
-// const isTransComponent = entity =>
-//   isComponent(entity) &&
-
-// const checkTransOn = obj =>
-//   get(obj, 'type') === 'MemberExpression' &&
-//   get(obj, 'property.name') === 'Trans';
-
-// // NOTE: Should `createElement` or `Trans` be configurable?
-// const isTransComponent = entity => {
-//   return isCreateElement(entity) && isTrans(entity.arguments);
-// };
-
 const replaceTagsRecursive = (collection, i, r) => {
-  // console.log('collection', i, collection.length, collection);
   return collection.reduce((result, entity) => {
-    // console.log('entity', i, entity);
-    // console.log('entity[0]', entity[0]);
-    // console.log("entity.type: ", get(entity, 'type'));
-    // console.log("entity.property.name", get(entity, 'property.name'));
-    // const isTransEntity = isTrans(entity);
     if (isElement(entity) && isTrans(entity)) {
-      // console.log('isTrans', entity)
       return result;
     }
 
@@ -52,12 +32,7 @@ const replaceTagsRecursive = (collection, i, r) => {
       const [name, props, ...children] = entity.arguments;
       name.value = i;
       name.raw = `"${i}"`;
-      // console.log('entity', entity, i)
-      // entity.arguments[0].value = i;
-      // entity.arguments[0].raw = `"${i}"`;
-      // entity.arguments = reject(entity.arguments, { type: 'ObjectExpression' });
 
-      console.log('children', children.length, children)
       replaceTagsRecursive(children, 0, []);
     }
 
@@ -70,8 +45,6 @@ const replaceTagsRecursive = (collection, i, r) => {
       entity.raw = `"${wrappedValue}"`;
     }
 
-    // console.log('entitas', entity);
-    // if (!isTrans(entity) && hasValue(entity)) i++;
     i++;
 
     result.push(entity);
@@ -80,7 +53,6 @@ const replaceTagsRecursive = (collection, i, r) => {
 };
 
 export const replaceTags = tree => {
-  console.log('tree', tree.length, tree)
   return replaceTagsRecursive(tree, 0, []);
 };
 


### PR DESCRIPTION
This fixes two issues:

1. Interpolations not at the root level (e.g. `<Trans><div>{{count}}</div></Trans>`) did not work.
2. The generated tag numbers did not seem to coincide with what i18next was expecting. See the changes to the existing tests for examples of old/new behavior.

I added a lot of (potentially brittle) tests in the course of fixing these bugs. They're not all the most well-thought-out tests, but I kept them as they help with documentation (and they all currently pass).